### PR TITLE
Update TinkersBoots.java - Fix for boots not showing in JEI

### DIFF
--- a/src/main/java/lance5057/tDefense/core/tools/armor/chain/TinkersBoots.java
+++ b/src/main/java/lance5057/tDefense/core/tools/armor/chain/TinkersBoots.java
@@ -31,10 +31,11 @@ import slimeknights.tconstruct.tools.TinkerTools;
 
 public class TinkersBoots extends ArmorCore {
 	public TinkersBoots() {
-		super(EntityEquipmentSlot.FEET, new PartMaterialType(TDParts.chainmail, HelmMaterialStats.TYPE),
+		super(EntityEquipmentSlot.FEET,
+				new PartMaterialType(TDParts.chainmail, HelmMaterialStats.TYPE),
 				PartMaterialType.handle(TDParts.armorPlate),
-				new PartMaterialType(TDParts.fabric, FabricMaterialStats.TYPE),
-				PartMaterialType.bowstring(TinkerTools.bowString));
+				PartMaterialType.extra(TinkerTools.bowString),
+				new PartMaterialType(TDParts.fabric, FabricMaterialStats.TYPE));
 		setUnlocalizedName("tinkersboots");
 	}
 


### PR DESCRIPTION
changing PartMaterialType to extra from bowstring fixes the problem of the boots not showing in JEI. guess bowstring cant be used.